### PR TITLE
FHE: export interface for rust FFI

### DIFF
--- a/FHE/DiscreteGauss.h
+++ b/FHE/DiscreteGauss.h
@@ -1,7 +1,7 @@
 #ifndef _DiscreteGauss
 #define _DiscreteGauss
 
-/* Class to sample from a Discrete Gauss distribution of 
+/* Class to sample from a Discrete Gauss distribution of
    standard deviation R
 */
 
@@ -17,70 +17,66 @@ class DiscreteGauss
    */
   int NewHopeB;
 
-  public:
-
+public:
   void set(double R);
 
-  void pack(octetStream& o) const { o.serialize(NewHopeB); }
-  void unpack(octetStream& o) { o.unserialize(NewHopeB); }
+  void pack(octetStream &o) const { o.serialize(NewHopeB); }
+  void unpack(octetStream &o) { o.unserialize(NewHopeB); }
 
   DiscreteGauss(double R) { set(R); }
 
   // Rely on default copy constructor/assignment
-  
-  int sample(PRNG& G, int stretch = 1) const;
+
+  int sample(PRNG &G, int stretch = 1) const;
   double get_R() const { return sqrt(0.5 * NewHopeB); }
   int get_NewHopeB() const { return NewHopeB; }
 
-  bool operator!=(const DiscreteGauss& other) const;
+  bool operator!=(const DiscreteGauss &other) const;
 };
 
-template<class T>
+template <class T>
 class RandomGenerator : public Generator<T>
 {
 protected:
   mutable PRNG G;
 
 public:
-  RandomGenerator(PRNG& G) { this->G.SetSeed(G); }
+  RandomGenerator(PRNG &G) { this->G.SetSeed(G); }
 };
 
-template<class T>
+template <class T>
 class UniformGenerator : public RandomGenerator<T>
 {
   int n_bits;
   bool positive;
 
 public:
-  UniformGenerator(PRNG& G, int n_bits, bool positive = true) :
-    RandomGenerator<T>(G), n_bits(n_bits), positive(positive) {}
-  Generator<T>* clone() const { return new UniformGenerator<T>(*this); }
-  void get(T& x) const  { this->G.get(x, n_bits, positive); }
+  UniformGenerator(PRNG &G, int n_bits, bool positive = true) : RandomGenerator<T>(G), n_bits(n_bits), positive(positive) {}
+  Generator<T> *clone() const { return new UniformGenerator<T>(*this); }
+  void get(T &x) const { this->G.get(x, n_bits, positive); }
 };
 
-template<class T = bigint>
+template <class T = bigint>
 class GaussianGenerator : public RandomGenerator<T>
 {
   DiscreteGauss DG;
   int stretch;
 
 public:
-  GaussianGenerator(const DiscreteGauss& DG, PRNG& G, int stretch = 1) :
-    RandomGenerator<T>(G), DG(DG), stretch(stretch) {}
-  Generator<T>* clone() const { return new GaussianGenerator<T>(*this); }
-  void get(T& x) const { x = DG.sample(this->G, stretch); }
+  GaussianGenerator(const DiscreteGauss &DG, PRNG &G, int stretch = 1) : RandomGenerator<T>(G), DG(DG), stretch(stretch) {}
+  Generator<T> *clone() const { return new GaussianGenerator<T>(*this); }
+  void get(T &x) const { x = DG.sample(this->G, stretch); }
 };
 
-int sample_half(PRNG& G);
+int sample_half(PRNG &G);
 
-template<class T>
+template <class T>
 class HalfGenerator : public RandomGenerator<T>
 {
 public:
-  HalfGenerator(PRNG& G) :
-    RandomGenerator<T>(G) {}
-  Generator<T>* clone() const { return new HalfGenerator<T>(*this); }
-  void get(T& x) const { x = sample_half(this->G); }
+  HalfGenerator(PRNG &G) : RandomGenerator<T>(G) {}
+  Generator<T> *clone() const { return new HalfGenerator<T>(*this); }
+  void get(T &x) const { x = sample_half(this->G); }
 };
 
 #endif

--- a/FHE/FHE_Params.cpp
+++ b/FHE/FHE_Params.cpp
@@ -6,19 +6,39 @@
 #include "Protocols/HemiOptions.h"
 #include "Processor/OnlineOptions.h"
 
-FHE_Params::FHE_Params(int n_mults, int drown_sec) :
-    FFTData(n_mults + 1), Chi(0.7), sec_p(drown_sec), matrix_dim(1)
+/*
+ * Exported for FFI
+ */
+
+/// Create a new FHE_Params object
+unique_ptr<FHE_Params> new_fhe_params(int n_mults, int drown_sec)
+{
+  return make_unique<FHE_Params>(n_mults, drown_sec);
+}
+
+/// Pass the underlying plaintext modulus to across the interface
+
+unique_ptr<bigint> get_plaintext_mod(const FHE_Params &params)
+{
+  return make_unique<bigint>(params.get_plaintext_modulus());
+}
+
+/*
+ * Implementation
+ */
+
+FHE_Params::FHE_Params(int n_mults, int drown_sec) : FFTData(n_mults + 1), Chi(0.7), sec_p(drown_sec), matrix_dim(1)
 {
 }
 
-void FHE_Params::set(const Ring& R,
-                     const vector<bigint>& primes)
+void FHE_Params::set(const Ring &R,
+                     const vector<bigint> &primes)
 {
   if (primes.size() != FFTData.size())
     throw runtime_error("wrong number of primes");
 
   for (size_t i = 0; i < FFTData.size(); i++)
-    FFTData[i].init(R,primes[i]);
+    FFTData[i].init(R, primes[i]);
 
   set_sec(sec_p);
 }
@@ -26,9 +46,10 @@ void FHE_Params::set(const Ring& R,
 void FHE_Params::set_sec(int sec)
 {
   assert(sec >= 0);
-  sec_p=sec;
-  Bval=1;  Bval=Bval<<sec_p;
-  Bval=FFTData[0].get_prime()/(2*(1+Bval));
+  sec_p = sec;
+  Bval = 1;
+  Bval = Bval << sec_p;
+  Bval = FFTData[0].get_prime() / (2 * (1 + Bval));
 }
 
 void FHE_Params::set_min_sec(int sec)
@@ -47,8 +68,7 @@ void FHE_Params::set_matrix_dim(int matrix_dim)
 void FHE_Params::set_matrix_dim_from_options()
 {
   set_matrix_dim(
-      HemiOptions::singleton.plain_matmul ?
-          1 : OnlineOptions::singleton.batch_size);
+      HemiOptions::singleton.plain_matmul ? 1 : OnlineOptions::singleton.batch_size);
 }
 
 bigint FHE_Params::Q() const
@@ -59,10 +79,10 @@ bigint FHE_Params::Q() const
   return res;
 }
 
-void FHE_Params::pack(octetStream& o) const
+void FHE_Params::pack(octetStream &o) const
 {
   o.store(FFTData.size());
-  for(auto& fd: FFTData)
+  for (auto &fd : FFTData)
     fd.pack(o);
   Chi.pack(o);
   Bval.pack(o);
@@ -71,12 +91,12 @@ void FHE_Params::pack(octetStream& o) const
   fd.pack(o);
 }
 
-void FHE_Params::unpack(octetStream& o)
+void FHE_Params::unpack(octetStream &o)
 {
   size_t size;
   o.get(size);
   FFTData.resize(size);
-  for (auto& fd : FFTData)
+  for (auto &fd : FFTData)
     fd.unpack(o);
   Chi.unpack(o);
   Bval.unpack(o);
@@ -85,13 +105,12 @@ void FHE_Params::unpack(octetStream& o)
   fd.unpack(o);
 }
 
-bool FHE_Params::operator!=(const FHE_Params& other) const
+bool FHE_Params::operator!=(const FHE_Params &other) const
 {
-  if (FFTData != other.FFTData or Chi != other.Chi or sec_p != other.sec_p
-      or Bval != other.Bval)
-    {
-      return true;
-    }
+  if (FFTData != other.FFTData or Chi != other.Chi or sec_p != other.sec_p or Bval != other.Bval)
+  {
+    return true;
+  }
   else
     return false;
 }
@@ -101,20 +120,20 @@ void FHE_Params::basic_generation_mod_prime(int plaintext_length)
   if (n_mults() == 0)
     generate_semi_setup(plaintext_length, 0, *this, fd, false);
   else
-    {
-      Parameters parameters(1, plaintext_length, 0);
-      parameters.generate_setup(*this, fd);
-    }
+  {
+    Parameters parameters(1, plaintext_length, 0);
+    parameters.generate_setup(*this, fd);
+  }
 }
 
-template<>
-const FFT_Data& FHE_Params::get_plaintext_field_data() const
+template <>
+const FFT_Data &FHE_Params::get_plaintext_field_data() const
 {
   return fd;
 }
 
-template<>
-const P2Data& FHE_Params::get_plaintext_field_data() const
+template <>
+const P2Data &FHE_Params::get_plaintext_field_data() const
 {
   throw not_implemented();
 }

--- a/FHE/FHE_Params.h
+++ b/FHE/FHE_Params.h
@@ -1,7 +1,7 @@
 #ifndef _FHE_Params
 #define _FHE_Params
 
-/* Class to hold the FHE Parameters 
+/* Class to hold the FHE Parameters
  *
  * The idea is that there is a single global FHE_Params structure
  * called params; which holds all the data
@@ -20,7 +20,7 @@
  */
 class FHE_Params
 {
-  protected:
+protected:
   // Pair of moduli in FFTData[0] and FFTData[1] for the levels
   vector<FFT_Data> FFTData;
 
@@ -34,8 +34,7 @@ class FHE_Params
 
   FFT_Data fd;
 
-  public:
-
+public:
   /**
    * Initialization.
    * @param n_mults number of ciphertext multiplications (0/1)
@@ -45,37 +44,37 @@ class FHE_Params
 
   int n_mults() const { return FFTData.size() - 1; }
 
-  void set(const Ring& R,const vector<bigint>& primes);
-  void set(const vector<bigint>& primes);
+  void set(const Ring &R, const vector<bigint> &primes);
+  void set(const vector<bigint> &primes);
   void set_sec(int sec);
   void set_min_sec(int sec);
 
   void set_matrix_dim(int matrix_dim);
   void set_matrix_dim_from_options();
-  int get_matrix_dim() const         { return matrix_dim; }
+  int get_matrix_dim() const { return matrix_dim; }
 
-  const vector<FFT_Data>& FFTD() const { return FFTData; }
+  const vector<FFT_Data> &FFTD() const { return FFTData; }
 
-  const bigint& p0() const           { return FFTData[0].get_prime(); }
-  const bigint& p1() const           { return FFTData[1].get_prime(); }
+  const bigint &p0() const { return FFTData[0].get_prime(); }
+  const bigint &p1() const { return FFTData[1].get_prime(); }
   bigint Q() const;
 
-  int secp() const                   { return sec_p;        }
-  const bigint& B() const            { return Bval;         }
-  double get_R() const               { return Chi.get_R();  }
-  void set_R(double R) const         { return Chi.set(R); }
-  DiscreteGauss get_DG() const       { return Chi; }
+  int secp() const { return sec_p; }
+  const bigint &B() const { return Bval; }
+  double get_R() const { return Chi.get_R(); }
+  void set_R(double R) const { return Chi.set(R); }
+  DiscreteGauss get_DG() const { return Chi; }
 
-  int phi_m() const                  { return FFTData[0].phi_m(); }
-  const Ring& get_ring()             { return FFTData[0].get_R(); }
+  int phi_m() const { return FFTData[0].phi_m(); }
+  const Ring &get_ring() { return FFTData[0].get_R(); }
 
   /// Append to buffer
-  void pack(octetStream& o) const;
+  void pack(octetStream &o) const;
 
   /// Read from buffer
-  void unpack(octetStream& o);
+  void unpack(octetStream &o);
 
-  bool operator!=(const FHE_Params& other) const;
+  bool operator!=(const FHE_Params &other) const;
 
   /**
    * Generate parameter for computation modulo a prime
@@ -83,10 +82,14 @@ class FHE_Params
    */
   void basic_generation_mod_prime(int plaintext_length);
 
-  template<class FD>
-  const FD& get_plaintext_field_data() const;
+  template <class FD>
+  const FD &get_plaintext_field_data() const;
 
   bigint get_plaintext_modulus() const;
 };
+
+/// Exported for rust FFI
+unique_ptr<FHE_Params> new_fhe_params(int n_mults, int drown_sec);
+unique_ptr<bigint> get_plaintext_mod(const FHE_Params &params);
 
 #endif

--- a/FHE/Rq_Element.cpp
+++ b/FHE/Rq_Element.cpp
@@ -4,59 +4,58 @@
 
 #include "Math/modp.hpp"
 
-Rq_Element::Rq_Element(const FHE_PK& pk) :
-        Rq_Element(pk.get_params().FFTD(), evaluation, evaluation)
+Rq_Element::Rq_Element(const FHE_PK &pk) : Rq_Element(pk.get_params().FFTD(), evaluation, evaluation)
 {
 }
 
-Rq_Element::Rq_Element(const vector<FFT_Data>& prd, RepType r0, RepType r1)
+Rq_Element::Rq_Element(const vector<FFT_Data> &prd, RepType r0, RepType r1)
 {
-    if (prd.size() > 0)
-        a.push_back({prd[0], r0});
-    if (prd.size() > 1)
-    {
-        assert(prd[0].get_R() == prd[1].get_R());
-        a.push_back({prd[1], r1});
-    }
-    lev = n_mults();
+  if (prd.size() > 0)
+    a.push_back({prd[0], r0});
+  if (prd.size() > 1)
+  {
+    assert(prd[0].get_R() == prd[1].get_R());
+    a.push_back({prd[1], r1});
+  }
+  lev = n_mults();
 }
 
-void Rq_Element::set_data(const vector<FFT_Data>& prd)
+void Rq_Element::set_data(const vector<FFT_Data> &prd)
 {
-    a.resize(prd.size(), {});
-    for(size_t i = 0; i < a.size(); i++)
-        a[i].set_data(prd[i]);
-    lev=n_mults();
+  a.resize(prd.size(), {});
+  for (size_t i = 0; i < a.size(); i++)
+    a[i].set_data(prd[i]);
+  lev = n_mults();
 }
 
-void Rq_Element::assign_zero(const vector<FFT_Data>& prd)
+void Rq_Element::assign_zero(const vector<FFT_Data> &prd)
 {
-    set_data(prd);
-    assign_zero();
+  set_data(prd);
+  assign_zero();
 }
 
 void Rq_Element::assign_zero()
 {
-	for (int i=0; i<=lev; ++i)
-		a[i].assign_zero();
+  for (int i = 0; i <= lev; ++i)
+    a[i].assign_zero();
 }
 
 void Rq_Element::assign_one()
 {
-	for (int i=0; i<=lev; ++i)
-		a[i].assign_one();
+  for (int i = 0; i <= lev; ++i)
+    a[i].assign_one();
 }
 
-void Rq_Element::partial_assign(const Rq_Element& other)
+void Rq_Element::partial_assign(const Rq_Element &other)
 {
-	lev=other.lev;
-	a.resize(other.a.size(), {});
+  lev = other.lev;
+  a.resize(other.a.size(), {});
 }
 
 void Rq_Element::negate()
 {
-	for (int i=0; i<=lev; ++i)
-		a[i].negate();
+  for (int i = 0; i <= lev; ++i)
+    a[i].negate();
 }
 
 Rq_Element Rq_Element::mul_by_X_i(int i) const
@@ -64,69 +63,75 @@ Rq_Element Rq_Element::mul_by_X_i(int i) const
   Rq_Element res;
   res.lev = lev;
   res.a.clear();
-  for (auto& x : a)
-    {
-      auto tmp = x.mul_by_X_i(i);
-      res.a.push_back(tmp);
-    }
+  for (auto &x : a)
+  {
+    auto tmp = x.mul_by_X_i(i);
+    res.a.push_back(tmp);
+  }
   return res;
 }
 
-void add(Rq_Element& ans,const Rq_Element& ra,const Rq_Element& rb)
+void add(Rq_Element &ans, const Rq_Element &ra, const Rq_Element &rb)
 {
   ans.partial_assign(ra, rb);
-  for (int i=0; i<=ans.lev; ++i)
-	  add(ans.a[i],ra.a[i],rb.a[i]);
-  if (ans.lev == 0 && ans.n_mults() == 1) {
-	  ans.a[1].partial_assign(ra.a[1]);
+  for (int i = 0; i <= ans.lev; ++i)
+    add(ans.a[i], ra.a[i], rb.a[i]);
+  if (ans.lev == 0 && ans.n_mults() == 1)
+  {
+    ans.a[1].partial_assign(ra.a[1]);
   }
 }
-void sub(Rq_Element& ans,const Rq_Element& a,const Rq_Element& b)
+void sub(Rq_Element &ans, const Rq_Element &a, const Rq_Element &b)
 {
   ans.partial_assign(a, b);
-  for (int i=0; i<=ans.lev; ++i)
-	  sub(ans.a[i],a.a[i],b.a[i]);
-  if (ans.lev == 0 && ans.n_mults() == 1) {
-	  ans.a[1].partial_assign(a.a[1]);
+  for (int i = 0; i <= ans.lev; ++i)
+    sub(ans.a[i], a.a[i], b.a[i]);
+  if (ans.lev == 0 && ans.n_mults() == 1)
+  {
+    ans.a[1].partial_assign(a.a[1]);
   }
 }
 
-void mul(Rq_Element& ans,const Rq_Element& a,const Rq_Element& b)
+void mul(Rq_Element &ans, const Rq_Element &a, const Rq_Element &b)
 {
   ans.partial_assign(a, b);
-  for (int i=0; i<=ans.lev; ++i)
-	  mul(ans.a[i],a.a[i],b.a[i]);
-  if (ans.lev == 0 && ans.n_mults() == 1) {
-	  ans.a[1].partial_assign(a.a[1]);
+  for (int i = 0; i <= ans.lev; ++i)
+    mul(ans.a[i], a.a[i], b.a[i]);
+  if (ans.lev == 0 && ans.n_mults() == 1)
+  {
+    ans.a[1].partial_assign(a.a[1]);
   }
 }
 
-void mul(Rq_Element& ans,const Rq_Element& a,const bigint& b)
+void mul(Rq_Element &ans, const Rq_Element &a, const bigint &b)
 {
   ans.partial_assign(a);
   modp bp;
-  for (int i=0; i<=ans.lev; ++i)
+  for (int i = 0; i <= ans.lev; ++i)
   {
-	  to_modp(bp,b,a.a[i].get_prD());
-	  mul(ans.a[i],a.a[i],bp);
+    to_modp(bp, b, a.a[i].get_prD());
+    mul(ans.a[i], a.a[i], bp);
   }
 }
 
-void Rq_Element::randomize(PRNG& G,int l)
+void Rq_Element::randomize(PRNG &G, int l)
 {
   set_level(l);
-  for (int i=0; i<=lev; ++i)
-	  a[i].randomize(G);
+  for (int i = 0; i <= lev; ++i)
+    a[i].randomize(G);
 }
 
-bool Rq_Element::equals(const Rq_Element& other) const
+bool Rq_Element::equals(const Rq_Element &other) const
 {
-  if (lev!=other.lev)                 { throw level_mismatch(); }
-  for (int i=0; i<=lev; ++i)
-	  if (!a[i].equals(other.a[i])) return false;
+  if (lev != other.lev)
+  {
+    throw level_mismatch();
+  }
+  for (int i = 0; i <= lev; ++i)
+    if (!a[i].equals(other.a[i]))
+      return false;
   return true;
 }
-
 
 vector<bigint> Rq_Element::to_vec_bigint() const
 {
@@ -137,30 +142,35 @@ vector<bigint> Rq_Element::to_vec_bigint() const
 
 // Doing sort of CRT;
 // result mod p0 = a[0]; result mod p1 = a[1]
-void Rq_Element::to_vec_bigint(vector<bigint>& v) const
+void Rq_Element::to_vec_bigint(vector<bigint> &v) const
 {
   a[0].to_vec_bigint(v);
-  if (n_mults() == 0) {
-	  bigint p0 = a[0].get_prime();
-	  for (size_t i = 0; i < v.size(); ++i) {
-		  if (v[i] > p0 / 2) {
-			  v[i] = (v[i] - p0);
-		  }
-	  }
-  }
-  if (lev==1)
-    { vector<bigint> v1;
-      a[1].to_vec_bigint(v1);
-      assert(v.size() == v1.size());
-      bigint p0=a[0].get_prime();
-      bigint p1=a[1].get_prime();
-      bigint p0i,lambda,Q=p0*p1;
-      invMod(p0i,p0%p1,p1);
-      for (unsigned int i=0; i<v.size(); i++)
-	{ lambda=((v1[i]-v[i])*p0i)%Q;
-          v[i]=(v[i]+p0*lambda)%Q;
-	}
+  if (n_mults() == 0)
+  {
+    bigint p0 = a[0].get_prime();
+    for (size_t i = 0; i < v.size(); ++i)
+    {
+      if (v[i] > p0 / 2)
+      {
+        v[i] = (v[i] - p0);
+      }
     }
+  }
+  if (lev == 1)
+  {
+    vector<bigint> v1;
+    a[1].to_vec_bigint(v1);
+    assert(v.size() == v1.size());
+    bigint p0 = a[0].get_prime();
+    bigint p1 = a[1].get_prime();
+    bigint p0i, lambda, Q = p0 * p1;
+    invMod(p0i, p0 % p1, p1);
+    for (unsigned int i = 0; i < v.size(); i++)
+    {
+      lambda = ((v1[i] - v[i]) * p0i) % Q;
+      v[i] = (v[i] + p0 * lambda) % Q;
+    }
+  }
 }
 
 ConversionIterator Rq_Element::get_iterator() const
@@ -175,54 +185,76 @@ bigint Rq_Element::infinity_norm() const
   bigint Q = 1, ans = 0;
   for (int i = 0; i <= n_mults(); ++i)
   {
-	  Q *= a[i].get_prime();
+    Q *= a[i].get_prime();
   }
   bigint t;
-  vector<bigint> te=to_vec_bigint();
-  for (unsigned int i=0; i<te.size(); i++)
-    { // Take rounded value and then abs value
-      if (te[i]<Q/2) { t=te[i]; }
-      else           { t=Q-te[i]; }
-      if (t>ans) { ans=t; }
+  vector<bigint> te = to_vec_bigint();
+  for (unsigned int i = 0; i < te.size(); i++)
+  { // Take rounded value and then abs value
+    if (te[i] < Q / 2)
+    {
+      t = te[i];
     }
+    else
+    {
+      t = Q - te[i];
+    }
+    if (t > ans)
+    {
+      ans = t;
+    }
+  }
   return ans;
 }
 
 void Rq_Element::change_rep(RepType r)
 {
-  if (lev==1) { throw level_mismatch(); }
+  if (lev == 1)
+  {
+    throw level_mismatch();
+  }
   a[0].change_rep(r);
 }
 
-void Rq_Element::change_rep(RepType r0,RepType r1)
+void Rq_Element::change_rep(RepType r0, RepType r1)
 {
-  if (lev==0 or n_mults() != 1) { throw level_mismatch(); }
+  if (lev == 0 or n_mults() != 1)
+  {
+    throw level_mismatch();
+  }
   a[0].change_rep(r0);
   a[1].change_rep(r1);
 }
 
-void Rq_Element::Scale(const bigint& p)
+void Rq_Element::Scale(const bigint &p)
 {
-  if (lev==0) { return; }
-  if (n_mults() == 0) {
-	  //for some reason we scale but we have just one level
-	  throw level_mismatch();
+  if (lev == 0)
+  {
+    return;
   }
-  bigint p0=a[0].get_prime(),p1=a[1].get_prime(),p1i,lambda,n=p1*p;
-  invMod(p1i,p1%p,p);
+  if (n_mults() == 0)
+  {
+    // for some reason we scale but we have just one level
+    throw level_mismatch();
+  }
+  bigint p0 = a[0].get_prime(), p1 = a[1].get_prime(), p1i, lambda, n = p1 * p;
+  invMod(p1i, p1 % p, p);
 
   // First multiply input by [p1]_p
-  bigint te=p1%p;
-  if (te>p/2) { te-=p; }
+  bigint te = p1 % p;
+  if (te > p / 2)
+  {
+    te -= p;
+  }
   modp tep;
-  to_modp(tep,te,a[0].get_prD());
-  mul(a[0],a[0],tep);
-  to_modp(tep,te,a[1].get_prD());
-  mul(a[1],a[1],tep);
+  to_modp(tep, te, a[0].get_prD());
+  mul(a[0], a[0], tep);
+  to_modp(tep, te, a[1].get_prD());
+  mul(a[1], a[1], tep);
 
   // Now compute delta
-  Ring_Element b0(a[0].get_FFTD(),evaluation);
-  Ring_Element b1(a[1].get_FFTD(),evaluation);
+  Ring_Element b0(a[0].get_FFTD(), evaluation);
+  Ring_Element b1(a[1].get_FFTD(), evaluation);
   // scope to ensure deconstruction of write iterators
   {
     auto poly_a1 = a[1];
@@ -232,50 +264,56 @@ void Rq_Element::Scale(const bigint& p)
     auto it1 = b1.get_write_iterator();
     bigint half_n = n / 2;
     bigint delta;
-    for (int i=0; i < a[1].get_FFTD().phi_m(); i++)
-      {
-        it.get(delta);
-        lambda = delta;
-        lambda *= p1i;
-        lambda %= p;
-        lambda *= p1;
-        lambda -= delta;
-        lambda %= n;
-        if (lambda > half_n)
-          lambda -= n;
-        it0.get(lambda);
-        it1.get(lambda);
-      }
+    for (int i = 0; i < a[1].get_FFTD().phi_m(); i++)
+    {
+      it.get(delta);
+      lambda = delta;
+      lambda *= p1i;
+      lambda %= p;
+      lambda *= p1;
+      lambda -= delta;
+      lambda %= n;
+      if (lambda > half_n)
+        lambda -= n;
+      it0.get(lambda);
+      it1.get(lambda);
+    }
   }
 
   // Now add delta back onto a0
-  Rq_Element bb(b0,b1);
-  ::add(*this,*this,bb);
+  Rq_Element bb(b0, b1);
+  ::add(*this, *this, bb);
 
   // Now divide by p1 mod p0
-  modp p1_inv,pp;
-  to_modp(pp,p1,a[0].get_prD());
-  Inv(p1_inv,pp,a[0].get_prD());
-  lev=0;
-  mul(a[0],a[0],p1_inv);
+  modp p1_inv, pp;
+  to_modp(pp, p1, a[0].get_prD());
+  Inv(p1_inv, pp, a[0].get_prD());
+  lev = 0;
+  mul(a[0], a[0], p1_inv);
 }
 
 void Rq_Element::mul_by_p1()
 {
 
-  if (n_mults() == 0) {throw level_mismatch();}
-  lev=1;
-  bigint m=a[1].get_prime()%a[0].get_prime();
+  if (n_mults() == 0)
+  {
+    throw level_mismatch();
+  }
+  lev = 1;
+  bigint m = a[1].get_prime() % a[0].get_prime();
   modp mp;
-  to_modp(mp,m,a[0].get_prD());
-  mul(a[0],a[0],mp);
+  to_modp(mp, m, a[0].get_prD());
+  mul(a[0], a[0], mp);
   a[1].assign_zero();
 }
 
 void Rq_Element::raise_level()
 {
-  if (lev==n_mults()) { return; }
-  lev=1;
+  if (lev == n_mults())
+  {
+    return;
+  }
+  lev = 1;
   a[1].from(a[0].get_copy_iterator());
 }
 
@@ -286,7 +324,7 @@ void Rq_Element::check_level() const
         "level out of range: " + to_string(lev) + "/" + to_string(n_mults()));
 }
 
-void Rq_Element::partial_assign(const Rq_Element& x, const Rq_Element& y)
+void Rq_Element::partial_assign(const Rq_Element &x, const Rq_Element &y)
 {
   x.check_level();
   y.check_level();
@@ -295,39 +333,41 @@ void Rq_Element::partial_assign(const Rq_Element& x, const Rq_Element& y)
   partial_assign(x);
 }
 
-void Rq_Element::pack(octetStream& o, int) const
+void Rq_Element::pack(octetStream &o, int) const
 {
   check_level();
   o.store(lev);
   for (int i = 0; i <= lev; ++i)
-	  a[i].pack(o);
+    a[i].pack(o);
 }
 
-void Rq_Element::unpack(octetStream& o, int)
+void Rq_Element::unpack(octetStream &o, int)
 {
-  unsigned int ll;  o.get(ll); lev=ll;
+  unsigned int ll;
+  o.get(ll);
+  lev = ll;
   check_level();
   for (int i = 0; i <= lev; ++i)
-	  a[i].unpack(o);
+    a[i].unpack(o);
 }
 
-void Rq_Element::output(ostream& s) const
+void Rq_Element::output(ostream &s) const
 {
   check_level();
-  s.write((char*)&lev, sizeof(lev));
+  s.write((char *)&lev, sizeof(lev));
   for (int i = 0; i <= lev; i++)
     a[i].output(s);
 }
 
-void Rq_Element::input(istream& s)
+void Rq_Element::input(istream &s)
 {
-  s.read((char*)&lev, sizeof(lev));
+  s.read((char *)&lev, sizeof(lev));
   check_level();
   for (int i = 0; i <= lev; i++)
     a[i].input(s);
 }
 
-void Rq_Element::check(const FHE_Params& params) const
+void Rq_Element::check(const FHE_Params &params) const
 {
   if (n_mults() != params.n_mults())
     throw level_mismatch();
@@ -339,12 +379,12 @@ size_t Rq_Element::report_size(ReportType type) const
 {
   size_t sz = a[0].report_size(type);
   if (lev == 1 || type == CAPACITY)
-	  if (n_mults() == 1)
-		  sz += a[1].report_size(type);
+    if (n_mults() == 1)
+      sz += a[1].report_size(type);
   return sz;
 }
 
-void Rq_Element::unpack(octetStream& o, const FHE_Params& params)
+void Rq_Element::unpack(octetStream &o, const FHE_Params &params)
 {
   set_data(params.FFTD());
   unpack(o);
@@ -356,16 +396,16 @@ void Rq_Element::print_first_non_zero() const
   size_t i;
   for (i = 0; i < v.size(); i++)
   {
-      if (v[i] != 0)
-      {
-          cout << i << ":" << v[i];
-          break;
-      }
+    if (v[i] != 0)
+    {
+      cout << i << ":" << v[i];
+      break;
+    }
   }
   if (i == v.size())
-      cout << "ZERO" << endl;
+    cout << "ZERO" << endl;
   cout << endl;
 }
 
-template void Rq_Element::from<bigint>(const Generator<bigint>&, int);
-template void Rq_Element::from<int>(const Generator<int>&, int);
+template void Rq_Element::from<bigint>(const Generator<bigint> &, int);
+template void Rq_Element::from<int>(const Generator<int> &, int);

--- a/FHE/Rq_Element.h
+++ b/FHE/Rq_Element.h
@@ -22,10 +22,10 @@
 
 // Forward declare the friend functions
 class Rq_Element;
-void add(Rq_Element& ans,const Rq_Element& a,const Rq_Element& b);
-void sub(Rq_Element& ans,const Rq_Element& a,const Rq_Element& b);
-void mul(Rq_Element& ans,const Rq_Element& a,const Rq_Element& b);
-void mul(Rq_Element& ans,const Rq_Element& a,const bigint& b);
+void add(Rq_Element &ans, const Rq_Element &a, const Rq_Element &b);
+void sub(Rq_Element &ans, const Rq_Element &a, const Rq_Element &b);
+void mul(Rq_Element &ans, const Rq_Element &a, const Rq_Element &b);
+void mul(Rq_Element &ans, const Rq_Element &a, const bigint &b);
 
 class Rq_Element
 {
@@ -34,154 +34,177 @@ protected:
   int lev;
 
   // Must be careful not to call by mistake
-  Rq_Element(RepType r0=evaluation,RepType r1=polynomial) :
-    a({r0, r1}), lev(n_mults()) {}
+  Rq_Element(RepType r0 = evaluation, RepType r1 = polynomial) : a({r0, r1}), lev(n_mults()) {}
 
-  public:
-  
+public:
   int n_mults() const { return a.size() - 1; }
 
   void change_rep(RepType r);
-  void change_rep(RepType r0,RepType r1);
+  void change_rep(RepType r0, RepType r1);
 
-  void set_data(const vector<FFT_Data>& prd);
-  void assign_zero(const vector<FFT_Data>& prd);
-  void assign_zero(); 
-  void assign_one(); 
-  void partial_assign(const Rq_Element& e);
+  void set_data(const vector<FFT_Data> &prd);
+  void assign_zero(const vector<FFT_Data> &prd);
+  void assign_zero();
+  void assign_one();
+  void partial_assign(const Rq_Element &e);
 
   // Pass in a pair of FFT_Data as a vector
-  Rq_Element(const vector<FFT_Data>& prd, RepType r0 = evaluation,
-      RepType r1 = polynomial);
+  Rq_Element(const vector<FFT_Data> &prd, RepType r0 = evaluation,
+             RepType r1 = polynomial);
 
-  Rq_Element(const FHE_Params& params, RepType r0, RepType r1) :
-      Rq_Element(params.FFTD(), r0, r1) {}
+  Rq_Element(const FHE_Params &params, RepType r0, RepType r1) : Rq_Element(params.FFTD(), r0, r1) {}
 
-  Rq_Element(const FHE_Params& params) :
-      Rq_Element(params.FFTD()) {}
+  Rq_Element(const FHE_Params &params) : Rq_Element(params.FFTD()) {}
 
-  Rq_Element(const FHE_PK& pk);
+  Rq_Element(const FHE_PK &pk);
 
-  Rq_Element(const Ring_Element& b0,const Ring_Element& b1) :
-    a({b0, b1}), lev(n_mults())
+  Rq_Element(const Ring_Element &b0, const Ring_Element &b1) : a({b0, b1}), lev(n_mults())
   {
     assert(b0.get_FFTD().get_R() == b1.get_FFTD().get_R());
   }
 
-  Rq_Element(const Ring_Element& b0) :
-    a({b0}), lev(n_mults()) {}
+  Rq_Element(const Ring_Element &b0) : a({b0}), lev(n_mults()) {}
 
-  template<class T, class FD, class S>
-  Rq_Element(const FHE_Params& params, const Plaintext<T, FD, S>& plaintext,
-      RepType r0 = polynomial, RepType r1 = polynomial) :
-      Rq_Element(params, r0, r1)
+  template <class T, class FD, class S>
+  Rq_Element(const FHE_Params &params, const Plaintext<T, FD, S> &plaintext,
+             RepType r0 = polynomial, RepType r1 = polynomial) : Rq_Element(params, r0, r1)
   {
     from(plaintext.get_iterator());
   }
 
-  template<class U, class V>
-  Rq_Element(const vector<FFT_Data>& prd, const vector<U>& b0,
-      const vector<V>& b1, RepType r = evaluation) :
-      Rq_Element(prd, r, r)
+  template <class U, class V>
+  Rq_Element(const vector<FFT_Data> &prd, const vector<U> &b0,
+             const vector<V> &b1, RepType r = evaluation) : Rq_Element(prd, r, r)
   {
     a[0] = Ring_Element(prd[0], r, b0);
     a[1] = Ring_Element(prd[1], r, b1);
   }
 
-  const Ring_Element& get(int i) const { return a[i]; }
+  const Ring_Element &get(int i) const { return a[i]; }
 
   /* Functional Operators */
   void negate();
-  friend void add(Rq_Element& ans,const Rq_Element& a,const Rq_Element& b);
-  friend void sub(Rq_Element& ans,const Rq_Element& a,const Rq_Element& b);
-  friend void mul(Rq_Element& ans,const Rq_Element& a,const Rq_Element& b);
-  friend void mul(Rq_Element& ans,const Rq_Element& a,const bigint& b);
+  friend void add(Rq_Element &ans, const Rq_Element &a, const Rq_Element &b);
+  friend void sub(Rq_Element &ans, const Rq_Element &a, const Rq_Element &b);
+  friend void mul(Rq_Element &ans, const Rq_Element &a, const Rq_Element &b);
+  friend void mul(Rq_Element &ans, const Rq_Element &a, const bigint &b);
 
-  template<class S>
-  Rq_Element& operator+=(const vector<S>& other);
+  template <class S>
+  Rq_Element &operator+=(const vector<S> &other);
 
-  Rq_Element& operator+=(const Rq_Element& other) { ::add(*this, *this, other); return *this; }
+  Rq_Element &operator+=(const Rq_Element &other)
+  {
+    ::add(*this, *this, other);
+    return *this;
+  }
 
-  Rq_Element operator+(const Rq_Element& b) const { Rq_Element res(*this); ::add(res, *this, b); return res; }
-  Rq_Element operator-(const Rq_Element& b) const { Rq_Element res(*this); sub(res, *this, b); return res; }
+  Rq_Element operator+(const Rq_Element &b) const
+  {
+    Rq_Element res(*this);
+    ::add(res, *this, b);
+    return res;
+  }
+  Rq_Element operator-(const Rq_Element &b) const
+  {
+    Rq_Element res(*this);
+    sub(res, *this, b);
+    return res;
+  }
   template <class T>
-  Rq_Element operator*(const T& b) const { Rq_Element res(*this); mul(res, *this, b); return res; }
+  Rq_Element operator*(const T &b) const
+  {
+    Rq_Element res(*this);
+    mul(res, *this, b);
+    return res;
+  }
 
   // Multiply something by p1 and make level 1
   void mul_by_p1();
 
   Rq_Element mul_by_X_i(int i) const;
 
-  void randomize(PRNG& G,int lev=-1);
+  void randomize(PRNG &G, int lev = -1);
 
   // Scale from level 1 to level 0, if at level 0 do nothing
-  void Scale(const bigint& p);
+  void Scale(const bigint &p);
 
-  bool equals(const Rq_Element& a) const;
-  bool operator==(const Rq_Element& a) const { return equals(a); }
-  bool operator!=(const Rq_Element& a) const { return !equals(a); }
+  bool equals(const Rq_Element &a) const;
+  bool operator==(const Rq_Element &a) const { return equals(a); }
+  bool operator!=(const Rq_Element &a) const { return !equals(a); }
 
   int level() const { return lev; }
-  void lower_level() { if (lev==1) { lev=0; }  }
+  void lower_level()
+  {
+    if (lev == 1)
+    {
+      lev = 0;
+    }
+  }
   // raise_level boosts a level 0 to a level 1 (or does nothing if level =1)
   void raise_level();
   void check_level() const;
   void set_level(int level) { lev = (level == -1 ? n_mults() : level); }
-  void partial_assign(const Rq_Element& a, const Rq_Element& b);
+  void partial_assign(const Rq_Element &a, const Rq_Element &b);
 
   // Converting to and from a vector of bigint's Again I/O is in poly rep
-  vector<bigint>  to_vec_bigint() const;
-  void to_vec_bigint(vector<bigint>& v) const;
+  vector<bigint> to_vec_bigint() const;
+  void to_vec_bigint(vector<bigint> &v) const;
 
   ConversionIterator get_iterator() const;
   template <class T>
-  void from(const Generator<T>& generator, int level=-1);
+  void from(const Generator<T> &generator, int level = -1);
 
   template <class T>
-  void from(const vector<T>& source, int level=-1)
-    {
-      for (auto& x : a)
-        assert(source.size() == (size_t) x.get_FFTD().phi_m());
-      from(Iterator<T>(source), level);
-    }
+  void from(const vector<T> &source, int level = -1)
+  {
+    for (auto &x : a)
+      assert(source.size() == (size_t)x.get_FFTD().phi_m());
+    from(Iterator<T>(source), level);
+  }
 
   bigint infinity_norm() const;
 
   bigint get_prime(int i) const
-    { return a[i].get_prime(); }
+  {
+    return a[i].get_prime();
+  }
 
   bigint get_modulus() const
-    { bigint ans=1;
-      for(int i=0; i<=lev; ++i) ans*=a[i].get_prime();
-      return ans;
-    }
+  {
+    bigint ans = 1;
+    for (int i = 0; i <= lev; ++i)
+      ans *= a[i].get_prime();
+    return ans;
+  }
 
-  /* Pack and unpack into an octetStream 
-   *   For unpack we assume the prData for a0 and a1 has been assigned 
+  /* Pack and unpack into an octetStream
+   *   For unpack we assume the prData for a0 and a1 has been assigned
    *   correctly already
    */
-  void pack(octetStream& o, int = -1) const;
-  void unpack(octetStream& o, int = -1);
+  void pack(octetStream &o, int = -1) const;
+  void unpack(octetStream &o, int = -1);
 
   // without prior initialization
-  void unpack(octetStream& o, const FHE_Params& params);
+  void unpack(octetStream &o, const FHE_Params &params);
 
-  void output(ostream& s) const;
-  void input(istream& s);
+  void output(ostream &s) const;
+  void input(istream &s);
 
-  void check(const FHE_Params& params) const;
+  void check(const FHE_Params &params) const;
 
   size_t report_size(ReportType type) const;
 
   void print_first_non_zero() const;
 };
-   
-template<int L>
-inline void mul(Rq_Element& ans,const bigint& a,const Rq_Element& b)
-{ mul(ans,b,a); }
 
-template<class S>
-Rq_Element& Rq_Element::operator+=(const vector<S>& other)
+template <int L>
+inline void mul(Rq_Element &ans, const bigint &a, const Rq_Element &b)
+{
+  mul(ans, b, a);
+}
+
+template <class S>
+Rq_Element &Rq_Element::operator+=(const vector<S> &other)
 {
   Rq_Element tmp = *this;
   tmp.from(Iterator<S>(other), lev);
@@ -190,15 +213,15 @@ Rq_Element& Rq_Element::operator+=(const vector<S>& other)
 }
 
 template <class T>
-void Rq_Element::from(const Generator<T>& generator, int level)
+void Rq_Element::from(const Generator<T> &generator, int level)
 {
   set_level(level);
   if (lev == 1)
-    {
-      auto clone = generator.clone();
-      a[1].from(*clone);
-      delete clone;
-    }
+  {
+    auto clone = generator.clone();
+    a[1].from(*clone);
+    delete clone;
+  }
   a[0].from(generator);
 }
 

--- a/Math/bigint.cpp
+++ b/Math/bigint.cpp
@@ -14,37 +14,55 @@ thread_local bigint bigint::tmp = 0;
 thread_local bigint bigint::tmp2 = 0;
 thread_local gmp_random bigint::random;
 
+/// Print the bigint
+void bigint::print() const
+{
+  cout << *this;
+}
 
-bigint powerMod(const bigint& x,const bigint& e,const bigint& p)
+bigint powerMod(const bigint &x, const bigint &e, const bigint &p)
 {
   bigint ans;
-  if (e>=0)
-    { mpz_powm(ans.get_mpz_t(),x.get_mpz_t(),e.get_mpz_t(),p.get_mpz_t()); }
+  if (e >= 0)
+  {
+    mpz_powm(ans.get_mpz_t(), x.get_mpz_t(), e.get_mpz_t(), p.get_mpz_t());
+  }
   else
-    { bigint xi,ei=-e;
-      invMod(xi,x,p);
-      mpz_powm(ans.get_mpz_t(),xi.get_mpz_t(),ei.get_mpz_t(),p.get_mpz_t()); 
-    }
-      
+  {
+    bigint xi, ei = -e;
+    invMod(xi, x, p);
+    mpz_powm(ans.get_mpz_t(), xi.get_mpz_t(), ei.get_mpz_t(), p.get_mpz_t());
+  }
+
   return ans;
 }
 
-
-int powerMod(int x,int e,int p)
+int powerMod(int x, int e, int p)
 {
-  if (e==1) { return x; }
-  if (e==0) { return 1; }
-  if (e<0)
-     { throw not_implemented(); }
-   int t=x,ans=1;
-   while (e!=0)
-     { if ((e&1)==1) { ans=(ans*t)%p; }
-       e>>=1;
-       t=(t*t)%p;
-     }
+  if (e == 1)
+  {
+    return x;
+  }
+  if (e == 0)
+  {
+    return 1;
+  }
+  if (e < 0)
+  {
+    throw not_implemented();
+  }
+  int t = x, ans = 1;
+  while (e != 0)
+  {
+    if ((e & 1) == 1)
+    {
+      ans = (ans * t) % p;
+    }
+    e >>= 1;
+    t = (t * t) % p;
+  }
   return ans;
 }
-
 
 size_t bigint::report_size(ReportType type) const
 {
@@ -73,21 +91,20 @@ int limb_size<int>()
   return 0;
 }
 
-bigint::bigint(const Integer& x) : bigint(SignedZ2<64>(x))
+bigint::bigint(const Integer &x) : bigint(SignedZ2<64>(x))
 {
 }
 
-
-bigint::bigint(const GC::Clear& x) : bigint(SignedZ2<64>(x))
+bigint::bigint(const GC::Clear &x) : bigint(SignedZ2<64>(x))
 {
 }
 
-bigint::bigint(const mp_limb_t* data, size_t n_limbs)
+bigint::bigint(const mp_limb_t *data, size_t n_limbs)
 {
   mpz_import(get_mpz_t(), n_limbs, -1, 8, -1, 0, data);
 }
 
-string to_string(const bigint& x)
+string to_string(const bigint &x)
 {
   stringstream ss;
   ss << x;

--- a/Math/bigint.h
+++ b/Math/bigint.h
@@ -22,15 +22,18 @@ enum ReportType
   REPORT_TYPE_MAX
 };
 
-template<int X, int L>
+template <int X, int L>
 class gfp_;
-template<int X, int L>
+template <int X, int L>
 class gfpvar_;
 class gmp_random;
 class Integer;
-template<int K> class Z2;
-template<int K> class SignedZ2;
-template<int L> class fixint;
+template <int K>
+class Z2;
+template <int K>
+class SignedZ2;
+template <int L>
+class fixint;
 
 namespace GC
 {
@@ -50,142 +53,151 @@ public:
   static thread_local bigint tmp, tmp2;
   static thread_local gmp_random random;
 
-  // workaround for GCC not always initializing thread_local variables
-  static void init_thread() { tmp = 0; tmp2 = 0; }
+  // Print the bigint
+  void print() const;
 
-  template<class T>
+  // workaround for GCC not always initializing thread_local variables
+  static void init_thread()
+  {
+    tmp = 0;
+    tmp2 = 0;
+  }
+
+  template <class T>
   static mpf_class get_float(T v, T p, T z, T s);
-  template<class U, class T>
-  static void output_float(U& o, const mpf_class& x, T nan);
+  template <class U, class T>
+  static void output_float(U &o, const mpf_class &x, T nan);
 
   /// Initialize to zero.
   bigint() : mpz_class() {}
   template <class T>
-  bigint(const T& x) : mpz_class(x) {}
+  bigint(const T &x) : mpz_class(x) {}
   /// Convert to canonical representation as non-negative number.
-  template<int X, int L>
-  bigint(const gfp_<X, L>& x);
+  template <int X, int L>
+  bigint(const gfp_<X, L> &x);
   /// Convert to canonical representation as non-negative number.
-  template<int X, int L>
-  bigint(const gfpvar_<X, L>& x);
-  /// Convert to canonical representation as non-negative number.
-  template <int K>
-  bigint(const Z2<K>& x);
+  template <int X, int L>
+  bigint(const gfpvar_<X, L> &x);
   /// Convert to canonical representation as non-negative number.
   template <int K>
-  bigint(const SignedZ2<K>& x);
+  bigint(const Z2<K> &x);
+  /// Convert to canonical representation as non-negative number.
+  template <int K>
+  bigint(const SignedZ2<K> &x);
   template <int L>
-  bigint(const fixint<L>& x) : bigint(typename fixint<L>::super(x)) {}
-  bigint(const Integer& x);
-  bigint(const GC::Clear& x);
-  bigint(const mp_limb_t* data, size_t n_limbs);
+  bigint(const fixint<L> &x) : bigint(typename fixint<L>::super(x)) {}
+  bigint(const Integer &x);
+  bigint(const GC::Clear &x);
+  bigint(const mp_limb_t *data, size_t n_limbs);
 
-  bigint& operator=(int n);
-  bigint& operator=(long n);
-  bigint& operator=(word n);
-  bigint& operator=(double f);
-  template<int X, int L>
-  bigint& operator=(const gfp_<X, L>& other);
-  template<int K>
-  bigint& operator=(const Z2<K>& x);
-  template<int K>
-  bigint& operator=(const SignedZ2<K>& x);
+  bigint &operator=(int n);
+  bigint &operator=(long n);
+  bigint &operator=(word n);
+  bigint &operator=(double f);
+  template <int X, int L>
+  bigint &operator=(const gfp_<X, L> &other);
+  template <int K>
+  bigint &operator=(const Z2<K> &x);
+  template <int K>
+  bigint &operator=(const SignedZ2<K> &x);
 
   /// Convert to signed representation in :math:`[-p/2,p/2]`.
-  template<int X, int L>
-  bigint& from_signed(const gfp_<X, L>& other);
-  template<class T>
-  bigint& from_signed(const T& other);
+  template <int X, int L>
+  bigint &from_signed(const gfp_<X, L> &other);
+  template <class T>
+  bigint &from_signed(const T &other);
 
-  void allocate_slots(const bigint& x) { *this = x; }
+  void allocate_slots(const bigint &x) { *this = x; }
   int get_min_alloc() { return get_mpz_t()->_mp_alloc; }
 
-  void mul(const bigint& x, const bigint& y) { *this = x * y; }
+  void mul(const bigint &x, const bigint &y) { *this = x * y; }
 
 #ifdef REALLOC_POLICE
   ~bigint() { lottery(); }
   void lottery();
 
-  bigint& operator-=(const bigint& y)
+  bigint &operator-=(const bigint &y)
   {
     if (rand() % 10000 == 0)
       if (get_mpz_t()->_mp_alloc < abs(y.get_mpz_t()->_mp_size) + 1)
         throw runtime_error("insufficient allocation");
-    ((mpz_class&)*this) -= y;
+    ((mpz_class &)*this) -= y;
     return *this;
   }
-  bigint& operator+=(const bigint& y)
+  bigint &operator+=(const bigint &y)
   {
     if (rand() % 10000 == 0)
       if (get_mpz_t()->_mp_alloc < abs(y.get_mpz_t()->_mp_size) + 1)
         throw runtime_error("insufficient allocation");
-    ((mpz_class&)*this) += y;
+    ((mpz_class &)*this) += y;
     return *this;
   }
 #endif
 
   int numBits() const
-  { return mpz_sizeinbase(get_mpz_t(), 2); }
+  {
+    return mpz_sizeinbase(get_mpz_t(), 2);
+  }
 
-  void generateUniform(PRNG& G, int n_bits, bool positive = false)
-  { G.get(*this, n_bits, positive); }
+  void generateUniform(PRNG &G, int n_bits, bool positive = false)
+  {
+    G.get(*this, n_bits, positive);
+  }
 
-  void pack(octetStream& os, int = -1) const { os.store(*this); }
-  void unpack(octetStream& os, int = -1)     { os.get(*this); };
+  void pack(octetStream &os, int = -1) const { os.store(*this); }
+  void unpack(octetStream &os, int = -1) { os.get(*this); };
 
   size_t report_size(ReportType type) const;
 };
 
+void inline_mpn_zero(mp_limb_t *x, mp_size_t size);
+void inline_mpn_copyi(mp_limb_t *dest, const mp_limb_t *src, mp_size_t size);
 
-void inline_mpn_zero(mp_limb_t* x, mp_size_t size);
-void inline_mpn_copyi(mp_limb_t* dest, const mp_limb_t* src, mp_size_t size);
-
-
-inline bigint& bigint::operator=(int n)
+inline bigint &bigint::operator=(int n)
 {
   mpz_class::operator=(n);
   return *this;
 }
 
-inline bigint& bigint::operator=(long n)
+inline bigint &bigint::operator=(long n)
 {
   mpz_class::operator=(n);
   return *this;
 }
 
-inline bigint& bigint::operator=(word n)
+inline bigint &bigint::operator=(word n)
 {
   mpz_class::operator=(n);
   return *this;
 }
 
-inline bigint& bigint::operator=(double f)
+inline bigint &bigint::operator=(double f)
 {
   mpz_class::operator=(f);
   return *this;
 }
 
-template<int K>
-bigint::bigint(const Z2<K>& x)
+template <int K>
+bigint::bigint(const Z2<K> &x)
 {
   *this = x;
 }
 
-template<int K>
-bigint& bigint::operator=(const Z2<K>& x)
+template <int K>
+bigint &bigint::operator=(const Z2<K> &x)
 {
   mpz_import(get_mpz_t(), Z2<K>::N_WORDS, -1, sizeof(mp_limb_t), 0, 0, x.get_ptr());
   return *this;
 }
 
-template<int K>
-bigint::bigint(const SignedZ2<K>& x)
+template <int K>
+bigint::bigint(const SignedZ2<K> &x)
 {
   *this = x;
 }
 
-template<int K>
-bigint& bigint::operator=(const SignedZ2<K>& x)
+template <int K>
+bigint &bigint::operator=(const SignedZ2<K> &x)
 {
   mpz_import(get_mpz_t(), Z2<K>::N_WORDS, -1, sizeof(mp_limb_t), 0, 0, x.get_ptr());
   if (x.negative())
@@ -197,138 +209,127 @@ bigint& bigint::operator=(const SignedZ2<K>& x)
   return *this;
 }
 
-template<int X, int L>
-bigint::bigint(const gfp_<X, L>& x)
+template <int X, int L>
+bigint::bigint(const gfp_<X, L> &x)
 {
   *this = x;
 }
 
-template<int X, int L>
-bigint::bigint(const gfpvar_<X, L>& other)
+template <int X, int L>
+bigint::bigint(const gfpvar_<X, L> &other)
 {
   to_bigint(*this, other.get(), other.get_ZpD());
 }
 
-template<int X, int L>
-bigint& bigint::operator=(const gfp_<X, L>& x)
+template <int X, int L>
+bigint &bigint::operator=(const gfp_<X, L> &x)
 {
   to_bigint(*this, x);
   return *this;
 }
 
-template<class T>
-void to_bigint(bigint& res, const T& other)
+template <class T>
+void to_bigint(bigint &res, const T &other)
 {
   other.to(res);
 }
 
-template<class T>
-void to_gfp(T& res, const bigint& a)
+template <class T>
+void to_gfp(T &res, const bigint &a)
 {
   res = a;
 }
 
-string to_string(const bigint& x);
+string to_string(const bigint &x);
 
 /**********************************
  *       Utility Functions        *
  **********************************/
 
-inline int gcd(const int x,const int y)
+inline int gcd(const int x, const int y)
 {
-  bigint& xx = bigint::tmp = x;
-  return mpz_gcd_ui(NULL,xx.get_mpz_t(),y);
+  bigint &xx = bigint::tmp = x;
+  return mpz_gcd_ui(NULL, xx.get_mpz_t(), y);
 }
 
-
-inline bigint gcd(const bigint& x,const bigint& y)
-{ 
+inline bigint gcd(const bigint &x, const bigint &y)
+{
   bigint g;
-  mpz_gcd(g.get_mpz_t(),x.get_mpz_t(),y.get_mpz_t());
+  mpz_gcd(g.get_mpz_t(), x.get_mpz_t(), y.get_mpz_t());
   return g;
 }
 
-
-inline void invMod(bigint& ans,const bigint& x,const bigint& p)
+inline void invMod(bigint &ans, const bigint &x, const bigint &p)
 {
-  mpz_invert(ans.get_mpz_t(),x.get_mpz_t(),p.get_mpz_t());
+  mpz_invert(ans.get_mpz_t(), x.get_mpz_t(), p.get_mpz_t());
 }
 
-inline int numBits(const bigint& m)
+inline int numBits(const bigint &m)
 {
   return m.numBits();
 }
 
-
-
 inline int numBits(long m)
 {
-  bigint& te = bigint::tmp = m;
-  return mpz_sizeinbase(te.get_mpz_t(),2);
+  bigint &te = bigint::tmp = m;
+  return mpz_sizeinbase(te.get_mpz_t(), 2);
 }
 
-
-
-inline size_t numBytes(const bigint& m)
+inline size_t numBytes(const bigint &m)
 {
-  return mpz_sizeinbase(m.get_mpz_t(),256);
+  return mpz_sizeinbase(m.get_mpz_t(), 256);
 }
 
-
-
-
-
-inline int probPrime(const bigint& x)
+inline int probPrime(const bigint &x)
 {
   int ans = mpz_probab_prime_p(x.get_mpz_t(), max(40, DEFAULT_SECURITY) / 2);
   return ans;
 }
 
-
-inline void bigintFromBytes(bigint& x,octet* bytes,int len)
+inline void bigintFromBytes(bigint &x, octet *bytes, int len)
 {
 #ifdef REALLOC_POLICE
   if (rand() % 10000 == 0)
     if (x.get_mpz_t()->_mp_alloc < ((len + 7) / 8))
       throw runtime_error("insufficient allocation");
 #endif
-  mpz_import(x.get_mpz_t(),len,1,sizeof(octet),0,0,bytes);
+  mpz_import(x.get_mpz_t(), len, 1, sizeof(octet), 0, 0, bytes);
 }
 
-
-inline void bytesFromBigint(octet* bytes,const bigint& x,unsigned int len)
+inline void bytesFromBigint(octet *bytes, const bigint &x, unsigned int len)
 {
   size_t ll = x == 0 ? 0 : numBytes(x);
-  if (ll>len)
-    { throw invalid_length(); }
+  if (ll > len)
+  {
+    throw invalid_length();
+  }
   memset(bytes, 0, len - ll);
   size_t l;
   mpz_export(bytes + len - ll, &l, 1, sizeof(octet), 0, 0, x.get_mpz_t());
   assert(ll == l);
 }
 
-
-inline int isOdd(const bigint& x)
+inline int isOdd(const bigint &x)
 {
   return mpz_odd_p(x.get_mpz_t());
 }
 
+template <class T>
+bigint sqrRootMod(const T &x);
 
-template<class T>
-bigint sqrRootMod(const T& x);
-
-bigint powerMod(const bigint& x,const bigint& e,const bigint& p);
+bigint powerMod(const bigint &x, const bigint &e, const bigint &p);
 
 // Assume e>=0
-int powerMod(int x,int e,int p);
+int powerMod(int x, int e, int p);
 
 inline int Hwt(int N)
 {
-  int result=0;
-  while(N)
-    { result++;
-      N&=(N-1);
-    }
+  int result = 0;
+  while (N)
+  {
+    result++;
+    N &= (N - 1);
+  }
   return result;
 }
 
@@ -336,4 +337,3 @@ template <class T>
 int limb_size();
 
 #endif
-


### PR DESCRIPTION
### Purpose
This PR adds helper method for exposing field access to opaque structs in the cxx interface on the rust side of [mp-spdz-rs](https://github.com/renegade-fi/ark-mpc). Most of the diff is formatter + linter changes

### Testing
- Methods work in `ark-mpc`