### PR TITLE
FHE: Ciphertext: Expose helpers for ciphertext <> plaintext ops

### DIFF
--- a/FHE/Ciphertext.cpp
+++ b/FHE/Ciphertext.cpp
@@ -8,6 +8,16 @@
  * FFI Exports
  */
 
+unique_ptr<Ciphertext> add_plaintext(const Ciphertext &c, const Plaintext_mod_prime &p)
+{
+  return make_unique<Ciphertext>(c + p);
+}
+
+unique_ptr<Ciphertext> mul_plaintext(const Ciphertext &c, const Plaintext_mod_prime &p)
+{
+  return make_unique<Ciphertext>(c * p);
+}
+
 unique_ptr<Ciphertext> add_ciphertexts(const Ciphertext &c0, const Ciphertext &c1)
 {
   unique_ptr<Ciphertext> result(new Ciphertext(c0.get_params()));

--- a/FHE/Ciphertext.h
+++ b/FHE/Ciphertext.h
@@ -94,7 +94,7 @@ public:
   void mul(const Ciphertext &c, const Plaintext_<FD> &a) { ::mul(*this, c, a); }
 
   template <class FD>
-  Ciphertext operator+(const Plaintext_<FD> &other)
+  Ciphertext operator+(const Plaintext_<FD> &other) const
   {
     Ciphertext res = *this;
     res += other;
@@ -199,6 +199,14 @@ public:
  * FFI Exports
  */
 
+/// Add a ciphertext and a plaintext
+///
+/// Allocates a result
+unique_ptr<Ciphertext> add_plaintext(const Ciphertext &c, const Plaintext_mod_prime &p);
+/// Multiply a ciphertext and a plaintext
+///
+/// Allocates a result
+unique_ptr<Ciphertext> mul_plaintext(const Ciphertext &c, const Plaintext_mod_prime &p);
 /// Add two ciphertexts
 ///
 /// Allocates a result

--- a/FHE/FHE_Keys.cpp
+++ b/FHE/FHE_Keys.cpp
@@ -28,14 +28,14 @@ unique_ptr<FHE_SK> get_sk(const FHE_KeyPair &pair)
   return unique_ptr<FHE_SK>(new FHE_SK(pair.sk));
 }
 
-unique_ptr<Ciphertext> encrypt(const FHE_KeyPair &pair, const Plaintext_<FFT_Data> &mess)
+unique_ptr<Ciphertext> encrypt(const FHE_PK &pk, const Plaintext_<FFT_Data> &mess)
 {
-  return make_unique<Ciphertext>(pair.pk.encrypt(mess));
+  return make_unique<Ciphertext>(pk.encrypt(mess));
 }
 
-unique_ptr<Plaintext_mod_prime> decrypt(FHE_KeyPair &pair, const Ciphertext &c)
+unique_ptr<Plaintext_mod_prime> decrypt(FHE_SK &sk, const Ciphertext &c)
 {
-  return make_unique<Plaintext_mod_prime>(pair.sk.decrypt(c));
+  return make_unique<Plaintext_mod_prime>(sk.decrypt(c));
 }
 
 /**

--- a/FHE/FHE_Keys.h
+++ b/FHE/FHE_Keys.h
@@ -275,8 +275,8 @@ unique_ptr<FHE_PK> get_pk(const FHE_KeyPair &pair);
 /// Get the secret key from a key pair
 unique_ptr<FHE_SK> get_sk(const FHE_KeyPair &pair);
 /// Encrypt a message with the keypair
-unique_ptr<Ciphertext> encrypt(const FHE_KeyPair &pair, const Plaintext_mod_prime &mess);
+unique_ptr<Ciphertext> encrypt(const FHE_PK &pk, const Plaintext_mod_prime &mess);
 /// Decrypt a message with the keypair
-unique_ptr<Plaintext_mod_prime> decrypt(FHE_KeyPair &pair, const Ciphertext &cipher);
+unique_ptr<Plaintext_mod_prime> decrypt(FHE_SK &sk, const Ciphertext &cipher);
 
 #endif

--- a/FHE/Plaintext.cpp
+++ b/FHE/Plaintext.cpp
@@ -23,6 +23,21 @@ void set_element_int(Plaintext_mod_prime &plaintext, size_t i, uint32_t value)
   plaintext.set_element(i, bigint(value));
 }
 
+unique_ptr<Plaintext_mod_prime> add_plaintexts(const Plaintext_mod_prime &x, const Plaintext_mod_prime &y)
+{
+  return make_unique<Plaintext_mod_prime>((x + y));
+}
+
+unique_ptr<Plaintext_mod_prime> sub_plaintexts(const Plaintext_mod_prime &x, const Plaintext_mod_prime &y)
+{
+  return make_unique<Plaintext_mod_prime>((x - y));
+}
+
+unique_ptr<Plaintext_mod_prime> mul_plaintexts(const Plaintext_mod_prime &x, const Plaintext_mod_prime &y)
+{
+  return make_unique<Plaintext_mod_prime>((x * y));
+}
+
 uint32_t get_element_int(const Plaintext_mod_prime &plaintext, size_t i)
 {
   // Get the element

--- a/FHE/Plaintext.h
+++ b/FHE/Plaintext.h
@@ -223,7 +223,7 @@ public:
     ::mul(*this, x, y);
   }
 
-  Plaintext operator*(const Plaintext &x)
+  Plaintext operator*(const Plaintext &x) const
   {
     Plaintext res(*Field_Data);
     res.mul(*this, x);
@@ -270,6 +270,14 @@ typedef Plaintext_<FFT_Data> Plaintext_mod_prime;
 
 /// Create a new plaintext object
 unique_ptr<Plaintext_mod_prime> new_plaintext(const FHE_Params &params);
+
+/// Add two plaintexts together
+unique_ptr<Plaintext_mod_prime> add_plaintexts(const Plaintext_mod_prime &x, const Plaintext_mod_prime &y);
+/// Subtract one plaintext from another
+unique_ptr<Plaintext_mod_prime> sub_plaintexts(const Plaintext_mod_prime &x, const Plaintext_mod_prime &y);
+/// Multiply two plaintexts together
+unique_ptr<Plaintext_mod_prime> mul_plaintexts(const Plaintext_mod_prime &x, const Plaintext_mod_prime &y);
+
 /// Set the element at index i to an integer value
 void set_element_int(Plaintext_mod_prime &plaintext, size_t i, uint32_t value);
 /// Get the element at index i as an integer value


### PR DESCRIPTION
### Purpose
This PR exposes two helpers for plaintext operations with ciphertexts