### PR TITLE
Math: bigint: Add conversion methods to/from bytes

### DIFF
--- a/FHE/Plaintext.cpp
+++ b/FHE/Plaintext.cpp
@@ -17,12 +17,6 @@ unique_ptr<Plaintext_mod_prime> new_plaintext(const FHE_Params &params)
   return make_unique<Plaintext_mod_prime>(params);
 }
 
-void set_element_int(Plaintext_mod_prime &plaintext, size_t i, uint32_t value)
-{
-  // Convert to bigint to preserve sign
-  plaintext.set_element(i, bigint(value));
-}
-
 unique_ptr<Plaintext_mod_prime> add_plaintexts(const Plaintext_mod_prime &x, const Plaintext_mod_prime &y)
 {
   return make_unique<Plaintext_mod_prime>((x + y));
@@ -38,6 +32,12 @@ unique_ptr<Plaintext_mod_prime> mul_plaintexts(const Plaintext_mod_prime &x, con
   return make_unique<Plaintext_mod_prime>((x * y));
 }
 
+void set_element_int(Plaintext_mod_prime &plaintext, size_t i, uint32_t value)
+{
+  // Convert to bigint to preserve sign
+  plaintext.set_element(i, bigint(value));
+}
+
 uint32_t get_element_int(const Plaintext_mod_prime &plaintext, size_t i)
 {
   // Get the element
@@ -49,6 +49,16 @@ uint32_t get_element_int(const Plaintext_mod_prime &plaintext, size_t i)
   pt_gfp.get().to_bigint(tmp, zp_data, true /* reduce */);
 
   return tmp.get_ui();
+}
+
+void set_element_bigint(Plaintext_mod_prime &plaintext, size_t i, const bigint &value)
+{
+  plaintext.set_element(i, value);
+}
+
+unique_ptr<bigint> get_element_bigint(const Plaintext_mod_prime &plaintext, size_t i)
+{
+  return make_unique<bigint>(plaintext.element(i));
 }
 
 /**

--- a/FHE/Plaintext.h
+++ b/FHE/Plaintext.h
@@ -282,5 +282,9 @@ unique_ptr<Plaintext_mod_prime> mul_plaintexts(const Plaintext_mod_prime &x, con
 void set_element_int(Plaintext_mod_prime &plaintext, size_t i, uint32_t value);
 /// Get the element at index i as an integer value
 uint32_t get_element_int(const Plaintext_mod_prime &plaintext, size_t i);
+/// Set the element at index i to a bigint value
+void set_element_bigint(Plaintext_mod_prime &plaintext, size_t i, const bigint &value);
+/// Get the element at index i as a bigint value
+unique_ptr<bigint> get_element_bigint(const Plaintext_mod_prime &plaintext, size_t i);
 
 #endif

--- a/Math/bigint.cpp
+++ b/Math/bigint.cpp
@@ -14,11 +14,41 @@ thread_local bigint bigint::tmp = 0;
 thread_local bigint bigint::tmp2 = 0;
 thread_local gmp_random bigint::random;
 
+/**
+ * FFI Exports
+ */
+
 /// Print the bigint
 void bigint::print() const
 {
   cout << *this;
 }
+
+unique_ptr<bigint> bigint_from_be_bytes(uint8_t *data, size_t size)
+{
+  unique_ptr<bigint> res(new bigint());
+
+  bigintFromBytes(*res, data, size);
+  return res;
+}
+
+rust::Vec<uint8_t> bigint_to_be_bytes(const bigint &x)
+{
+  auto size = numBytes(x);
+  vector<uint8_t> res = vector<uint8_t>(size);
+  bytesFromBigint(res.data(), x, size);
+
+  // Convert the std vec into a rust vec
+  rust::Vec<uint8_t> rust_res;
+  rust_res.reserve(size);
+
+  std::copy(res.begin(), res.end(), std::back_inserter(rust_res));
+  return rust_res;
+}
+
+/**
+ * Implementation
+ */
 
 bigint powerMod(const bigint &x, const bigint &e, const bigint &p)
 {

--- a/Math/bigint.h
+++ b/Math/bigint.h
@@ -13,6 +13,7 @@ using namespace std;
 #include "Tools/octetStream.h"
 #include "Tools/avx_memcpy.h"
 #include "Protocols/config.h"
+#include "rust/cxx.h"
 
 enum ReportType
 {
@@ -335,5 +336,18 @@ inline int Hwt(int N)
 
 template <class T>
 int limb_size();
+
+/**
+ * FFI Exports
+ */
+
+/// Convert a byte array to a bigint
+///
+/// Allocate a new bigint
+unique_ptr<bigint> bigint_from_be_bytes(uint8_t *bytes, size_t len);
+/// Convert a byte array to a bigint
+///
+/// Allocates a new buffer
+rust::Vec<uint8_t> bigint_to_be_bytes(const bigint &x);
 
 #endif


### PR DESCRIPTION
### Purpose
This PR adds conversion methods to and from bytes for `bigint` types that are exported via the FFI

