### PR TITLE
FHE, Math: Expose clone methods on all FFI types

### DIFF
--- a/FHE/Ciphertext.h
+++ b/FHE/Ciphertext.h
@@ -44,6 +44,11 @@ public:
     set(a0, a1, C.get_pk_id());
   }
 
+  /**
+   * Clone the value, made explicit here to support clones across the ffi
+   */
+  unique_ptr<Ciphertext> clone() const { return unique_ptr<Ciphertext>(new Ciphertext(*this)); }
+
   // Rely on default copy assignment/constructor
 
   word get_pk_id() const { return pk_id; }

--- a/FHE/FHE_Keys.h
+++ b/FHE/FHE_Keys.h
@@ -27,6 +27,11 @@ public:
 
   const FHE_Params &get_params() const { return *params; }
 
+  /**
+   * Clone the value, made explicit here to support clones across the ffi
+   */
+  unique_ptr<FHE_SK> clone() const { return unique_ptr<FHE_SK>(new FHE_SK(*this)); }
+
   bigint p() const { return pr; }
 
   // secret key always on lower level
@@ -135,6 +140,11 @@ class FHE_PK
 public:
   const FHE_Params &get_params() const { return *params; }
 
+  /**
+   * Clone the value, made explicit here to support clones across the ffi
+   */
+  unique_ptr<FHE_PK> clone() const { return unique_ptr<FHE_PK>(new FHE_PK(*this)); }
+
   bigint p() const { return pr; }
 
   void assign(const Rq_Element &a, const Rq_Element &b,
@@ -241,6 +251,11 @@ public:
   FHE_KeyPair(const FHE_Params &params) : pk(params), sk(params)
   {
   }
+
+  /**
+   * Clone the value, made explicit here to support clones across the ffi
+   */
+  unique_ptr<FHE_KeyPair> clone() const { return unique_ptr<FHE_KeyPair>(new FHE_KeyPair(*this)); }
 
   void generate(PRNG &G)
   {

--- a/FHE/FHE_Params.h
+++ b/FHE/FHE_Params.h
@@ -42,6 +42,12 @@ public:
    */
   FHE_Params(int n_mults = 1, int drown_sec = DEFAULT_SECURITY);
 
+  /**
+   * Clone the FHE_Params
+   * Made explicit here to support clnoning across the ffi
+   */
+  unique_ptr<FHE_Params> clone() const { return unique_ptr<FHE_Params>(new FHE_Params(*this)); };
+
   int n_mults() const { return FFTData.size() - 1; }
   uint32_t n_plaintext_slots() const { return static_cast<uint32_t>(fd.phi_m()); }
 

--- a/FHE/Plaintext.h
+++ b/FHE/Plaintext.h
@@ -101,6 +101,11 @@ public:
   /// Initialization
   Plaintext(const FHE_Params &params);
 
+  /**
+   * Clone the Plaintext, made explicit here to support cloning across the ffi
+   */
+  unique_ptr<Plaintext> clone() const { return unique_ptr<Plaintext>(new Plaintext(*this)); }
+
   void allocate(PT_Type type) const;
   void allocate() const { allocate(type); }
   void allocate_slots(const bigint &value);

--- a/Math/bigint.h
+++ b/Math/bigint.h
@@ -56,6 +56,8 @@ public:
 
   // Print the bigint
   void print() const;
+  /// Create a copy of the bigint
+  inline unique_ptr<bigint> clone() const { return unique_ptr<bigint>(new bigint(*this)); }
 
   // workaround for GCC not always initializing thread_local variables
   static void init_thread()


### PR DESCRIPTION
### Purpose
This PR exposes `clone` methods that allow an FFI to access the copy constructors on types that are exposed across the FFI